### PR TITLE
For now, require openmpi=4 for osx since...

### DIFF
--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -16,7 +16,5 @@ channel_targets:
 - conda-forge main
 macos_machine:
 - x86_64-apple-darwin13.4.0
-openmpi:
-- '4'
 target_platform:
 - osx-64

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -16,7 +16,5 @@ channel_targets:
 - conda-forge main
 macos_machine:
 - arm64-apple-darwin20.0.0
-openmpi:
-- '4'
 target_platform:
 - osx-arm64

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   folder: src
 
 build:
-  number: 0
+  number: 1
 
 outputs:
 
@@ -30,7 +30,8 @@ outputs:
         - winflexbison  # [win]
         - mslex  # [win]
         - msmpi  # [win]
-        - openmpi  # [not win]
+        - openmpi=4  # [osx]
+        - openmpi  # [not (win or osx)]
       host:
         - dirent  # [win]
       run:
@@ -46,7 +47,8 @@ outputs:
         - ply
         - mslex  # [win]
         - msmpi  # [win]
-        - openmpi  # [not win]
+        - openmpi=4  # [osx]
+        - openmpi  # [not (win or osx)]
         - nexus  # [not (aarch64 or ppc64le)]
         - nexpy  # [not (aarch64 or ppc64le)]
     test:


### PR DESCRIPTION
experiencing crashes with macOS and latest openmpi with Union-oriented instruments...

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
